### PR TITLE
Show legislator endpoint

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,0 +1,3 @@
+class Api::V1::ApiController < ApplicationController
+  protect_from_forgery with: :null_session
+end

--- a/app/controllers/api/v1/legislators_controller.rb
+++ b/app/controllers/api/v1/legislators_controller.rb
@@ -1,0 +1,2 @@
+class Api::V1::LegislatorsController < Api::V1::ApiController
+end

--- a/app/controllers/api/v1/legislators_controller.rb
+++ b/app/controllers/api/v1/legislators_controller.rb
@@ -1,2 +1,7 @@
 class Api::V1::LegislatorsController < Api::V1::ApiController
+  respond_to :json
+
+  def show
+    respond_with Legislator.find(params[:id])
+  end
 end

--- a/app/models/legislator.rb
+++ b/app/models/legislator.rb
@@ -1,0 +1,2 @@
+class Legislator < ActiveRecord::Base
+end

--- a/app/serializers/legislator_serializer.rb
+++ b/app/serializers/legislator_serializer.rb
@@ -1,0 +1,16 @@
+class LegislatorSerializer < ActiveModel::Serializer
+  attributes :name,
+             :state,
+             :district,
+             :political_party,
+             :term_starts_on,
+             :term_ends_on
+
+  def term_starts_on
+    object.term_starts_on.strftime("%Y-%m-%d")
+  end
+
+  def term_ends_on
+    object.term_ends_on.strftime("%Y-%m-%d")
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,56 +1,7 @@
 Rails.application.routes.draw do
-  # The priority is based upon order of creation: first created -> highest priority.
-  # See how all your routes lay out with "rake routes".
-
-  # You can have the root of your site routed with "root"
-  # root 'welcome#index'
-
-  # Example of regular route:
-  #   get 'products/:id' => 'catalog#view'
-
-  # Example of named route that can be invoked with purchase_url(id: product.id)
-  #   get 'products/:id/purchase' => 'catalog#purchase', as: :purchase
-
-  # Example resource route (maps HTTP verbs to controller actions automatically):
-  #   resources :products
-
-  # Example resource route with options:
-  #   resources :products do
-  #     member do
-  #       get 'short'
-  #       post 'toggle'
-  #     end
-  #
-  #     collection do
-  #       get 'sold'
-  #     end
-  #   end
-
-  # Example resource route with sub-resources:
-  #   resources :products do
-  #     resources :comments, :sales
-  #     resource :seller
-  #   end
-
-  # Example resource route with more complex sub-resources:
-  #   resources :products do
-  #     resources :comments
-  #     resources :sales do
-  #       get 'recent', on: :collection
-  #     end
-  #   end
-
-  # Example resource route with concerns:
-  #   concern :toggleable do
-  #     post 'toggle'
-  #   end
-  #   resources :posts, concerns: :toggleable
-  #   resources :photos, concerns: :toggleable
-
-  # Example resource route within a namespace:
-  #   namespace :admin do
-  #     # Directs /admin/products/* to Admin::ProductsController
-  #     # (app/controllers/admin/products_controller.rb)
-  #     resources :products
-  #   end
+  namespace :api, defaults: { format: :json } do
+    namespace :v1 do
+      resources :legislators,  only: [:show]
+    end
+  end
 end

--- a/db/migrate/20160511222147_create_legislators.rb
+++ b/db/migrate/20160511222147_create_legislators.rb
@@ -1,0 +1,14 @@
+class CreateLegislators < ActiveRecord::Migration
+  def change
+    create_table :legislators do |t|
+      t.string :name
+      t.string :state
+      t.integer :district
+      t.string :political_party
+      t.datetime :term_starts_on
+      t.datetime :term_ends_on
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,19 @@
+# encoding: UTF-8
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 0) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,9 +11,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 20160511222147) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "legislators", force: :cascade do |t|
+    t.string   "name"
+    t.string   "state"
+    t.integer  "district"
+    t.string   "political_party"
+    t.datetime "term_starts_on"
+    t.datetime "term_ends_on"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
 
 end

--- a/spec/controllers/api/v1/legislators_controller_spec.rb
+++ b/spec/controllers/api/v1/legislators_controller_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::LegislatorsController, type: :controller do
+  it "show should return a successful response and return a legislator" do
+    legislator = Legislator.create(name: "John Smith",
+                                   state: "CA",
+                                   district: 1,
+                                   political_party: "independent",
+                                   term_starts_on: DateTime.new(2016, 02, 01),
+                                   term_ends_on: DateTime.new(2018, 02, 01))
+
+    get :show, id: legislator.id, format: :json
+
+    expect(response.status).to eq 200
+
+    api_legislator = JSON.parse(response.body)
+
+    expect(api_legislator['name']).to eq legislator.name
+    expect(api_legislator['state']).to eq legislator.state
+    expect(api_legislator['district']).to eq legislator.district
+    expect(api_legislator['political_party']).to eq legislator.political_party
+    expect(api_legislator['term_starts_on']).to eq "2016-02-01"
+    expect(api_legislator['term_ends_on']).to eq "2018-02-01"
+    expect(api_legislator['created_at']).to eq nil
+    expect(api_legislator['updated_at']).to eq nil
+  end
+end

--- a/spec/models/legislator_spec.rb
+++ b/spec/models/legislator_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Legislator, type: :model do
+  it "should be create valid legislator" do
+    legislator = Legislator.new(name: "John Smith",
+                                   state: "CA",
+                                   district: 1,
+                                   political_party: "independent",
+                                   term_starts_on: DateTime.new(2016, 02, 01),
+                                   term_ends_on: DateTime.new(2018, 02, 01))
+                                   
+    expect(legislator.valid?).to be true
+  end
+end

--- a/spec/models/legislator_spec.rb
+++ b/spec/models/legislator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Legislator, type: :model do
                                    political_party: "independent",
                                    term_starts_on: DateTime.new(2016, 02, 01),
                                    term_ends_on: DateTime.new(2018, 02, 01))
-                                   
+
     expect(legislator.valid?).to be true
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,53 +5,24 @@ require File.expand_path('../../config/environment', __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'
-# Add additional requires below this line. Rails is not loaded until this point!
+require 'database_cleaner'
 
-# Requires supporting ruby files with custom matchers and macros, etc, in
-# spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
-# run as spec files by default. This means that files in spec/support that end
-# in _spec.rb will both be required and run as specs, causing the specs to be
-# run twice. It is recommended that you do not name files matching this glob to
-# end with _spec.rb. You can configure this pattern with the --pattern
-# option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
-#
-# The following line is provided for convenience purposes. It has the downside
-# of increasing the boot-up time by auto-requiring all files in the support
-# directory. Alternatively, in the individual `*_spec.rb` files, manually
-# require only the support files necessary.
-#
-# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
-
-# Checks for pending migration and applies them before tests are run.
-# If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
-  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
-
-  # If you're not using ActiveRecord, or you'd prefer not to run each of your
-  # examples within a transaction, remove the following line or assign false
-  # instead of true.
   config.use_transactional_fixtures = true
-
-  # RSpec Rails can automatically mix in different behaviours to your tests
-  # based on their file location, for example enabling you to call `get` and
-  # `post` in specs under `spec/controllers`.
-  #
-  # You can disable this behaviour by removing the line below, and instead
-  # explicitly tag your specs with their type, e.g.:
-  #
-  #     RSpec.describe UsersController, :type => :controller do
-  #       # ...
-  #     end
-  #
-  # The different available types are documented in the features, such as in
-  # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
-
-  # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!
-  # arbitrary gems may also be filtered via:
-  # config.filter_gems_from_backtrace("gem name")
+
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.around(:each) do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
+  end
 end


### PR DESCRIPTION
API for legislators created with a show endpoint. A serializer formats the datetime attributes `term_starts_on` and `term_ends_on` to show readable dates. Serializer omits `created_at` and `updated_at` attributes from the response.
