### PR TITLE
Create legislator endpoint

### DIFF
--- a/app/controllers/api/v1/legislators_controller.rb
+++ b/app/controllers/api/v1/legislators_controller.rb
@@ -4,4 +4,19 @@ class Api::V1::LegislatorsController < Api::V1::ApiController
   def show
     respond_with Legislator.find(params[:id])
   end
+
+  def create
+    respond_with :api, :v1, Legislator.create(legislator_params)
+  end
+
+  private
+
+    def legislator_params
+      params.require(:legislator).permit(:name,
+                                         :state,
+                                         :district,
+                                         :political_party,
+                                         :term_starts_on,
+                                         :term_ends_on)
+    end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   namespace :api, defaults: { format: :json } do
     namespace :v1 do
-      resources :legislators,  only: [:show]
+      resources :legislators,  only: [:show, :create]
     end
   end
 end

--- a/spec/controllers/api/v1/legislators_controller_spec.rb
+++ b/spec/controllers/api/v1/legislators_controller_spec.rb
@@ -24,4 +24,31 @@ RSpec.describe Api::V1::LegislatorsController, type: :controller do
     expect(api_legislator['created_at']).to eq nil
     expect(api_legislator['updated_at']).to eq nil
   end
+
+  it "creates a legislator and receives a 201 response" do
+    legislator_data =
+      {
+        name: "John Smith",
+        state: "CA",
+        district: 1,
+        political_party: "independent",
+        term_starts_on: "2016-02-01",
+        term_ends_on: "2018-02-01"
+      }
+
+    post :create, format: :json, legislator: legislator_data
+
+    expect(response.status).to eq 201
+
+    api_item_1 = JSON.parse(response.body)
+
+    expect(api_item_1['name']).to eq "John Smith"
+    expect(api_item_1['state']).to eq "CA"
+    expect(api_item_1['district']).to eq 1
+    expect(api_item_1['political_party']).to eq "independent"
+    expect(api_item_1['term_starts_on']).to eq "2016-02-01"
+    expect(api_item_1['term_ends_on']).to eq "2018-02-01"
+    expect(api_item_1['created_at']).to eq nil
+    expect(api_item_1['updated_at']).to eq nil
+  end
 end


### PR DESCRIPTION
API endpoint for creating a user complete. In controller, the object creation had to be namespaced with ap1/v1 for the responders gem to recognize the correct route to post to.
