### PR TITLE
Add id to legislator serializer

### DIFF
--- a/app/serializers/legislator_serializer.rb
+++ b/app/serializers/legislator_serializer.rb
@@ -1,5 +1,6 @@
 class LegislatorSerializer < ActiveModel::Serializer
-  attributes :name,
+  attributes :id,
+             :name,
              :state,
              :district,
              :political_party,

--- a/spec/controllers/api/v1/legislators_controller_spec.rb
+++ b/spec/controllers/api/v1/legislators_controller_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Api::V1::LegislatorsController, type: :controller do
 
     api_legislator = JSON.parse(response.body)
 
+    expect(api_legislator['id']).to eq legislator.id
     expect(api_legislator['name']).to eq legislator.name
     expect(api_legislator['state']).to eq legislator.state
     expect(api_legislator['district']).to eq legislator.district
@@ -42,6 +43,7 @@ RSpec.describe Api::V1::LegislatorsController, type: :controller do
 
     api_item_1 = JSON.parse(response.body)
 
+    expect(api_item_1['id']).to eq Legislator.last.id
     expect(api_item_1['name']).to eq "John Smith"
     expect(api_item_1['state']).to eq "CA"
     expect(api_item_1['district']).to eq 1


### PR DESCRIPTION
Fixed bug where legislator endpoint did not include `id`. Updated controller tests.
